### PR TITLE
Remove redundants

### DIFF
--- a/src/components/Footer/data.js
+++ b/src/components/Footer/data.js
@@ -28,11 +28,11 @@ export default [
   {
     name: 'Funds',
     members: [
-      {
+      /*{
         name: 'StuD Fonds',
         img: stud,
         url: 'https://www.stud.nl/',
-      },
+      },*/
       /*{
         name: 'Timman Fonds',
         img: timman,

--- a/src/pages/home.js
+++ b/src/pages/home.js
@@ -37,17 +37,5 @@ export default () => (
         {/*</Column>*/}
         {/*</Row>*/}
         {/*</Section>*/}
-        <Section id="CvA">
-            <Row>
-                <Column size={9} lSize={9} mSize={12}>
-                    {<H3>Board of Recommendation</H3>}
-                    {<Text>The following people, speaking for their respectable institutions acknowledge the importance
-                        and
-                        competence of the symposium and recommend supporting the organisation.</Text>}
-
-                </Column>
-            </Row>
-            <CvA/>
-        </Section>
     </Page>
 )


### PR DESCRIPTION
As discussed in last meeting: CvA will be removed from home page and STuD temporarily as funds partner. 