### PR TITLE
Add copyright information option to images

### DIFF
--- a/src/components/Event/index.js
+++ b/src/components/Event/index.js
@@ -31,12 +31,17 @@ const TextLabel = styled.strong`
   }
 `
 
-const Event = ({start, end, meta, title, bgImage, abstract, name, bio}) =>
+const Event = ({start, end, meta, title, bgImage, abstract, name, bio, imgCopyright}) =>
   <div>
     <Section>
       <Row rtl>
         <Column size={6} mSize={12}>
-          <Image src={bgImage} alt={title} />
+            <Row>
+                <Image src={bgImage} title={title} />
+            </Row>
+            <Row>
+                <Text>{imgCopyright ? "© " + imgCopyright : name}</Text>
+            </Row>
         </Column>
         <Column size={6} mSize={12}>
           <H2>{title}</H2>

--- a/src/components/Person/Avatar.js
+++ b/src/components/Person/Avatar.js
@@ -13,7 +13,7 @@ function* duoRand(min, max) {
 const gen = duoRand(90, 110)
 
 const Avatar = styled.img.attrs({
-  alt: ({name}) => name,
+  title: ({name}) => name,
   src: ({img}) => img,
   style: _ => ({
     borderTopLeftRadius: `${gen.next().value}% ${gen.next().value}%`,

--- a/src/components/Program/EventContent.js
+++ b/src/components/Program/EventContent.js
@@ -55,9 +55,9 @@ const EventButton = styled(Button)`
   float: right;
 `
 
-export default ({bgImage, title, meta, active, ...rest}) =>
+export default ({bgImage, title, meta, active, imgCopyright, ...rest}) =>
   <EventContent {...rest} active={active} large={!!bgImage}>
-    <Image src={bgImage} />
+    <Image src={bgImage} title={imgCopyright ? "© " + imgCopyright : meta}/>
     <Title>{title}</Title>
     {meta
       ? <Text>{meta}</Text>

--- a/src/components/Program/data.js
+++ b/src/components/Program/data.js
@@ -31,6 +31,7 @@ const events = [
     // FIXME: when speaker tiles are rendered from the home page the event that is linked is always the speaker name with hyphens, therefore they must match (see components/Speakers/Speaker.js).
     event: 'eva-de-valk',
     bgImage: eva,
+    imgCopyright: 'Enith van Tongeren',
   },
   {
     active: true,

--- a/src/components/Speakers/data.js
+++ b/src/components/Speakers/data.js
@@ -14,6 +14,7 @@ export default [
     links: [],
     revealed: true,
     img: eva,
+    //imgCopyright: 'Enith van Tongeren',
     name: 'Eva de Valk',
     bio: `Eva de Valk is a journalist, speaker and chairman. She wants to understand how society is changing and is fascinated by the impact of technology on society. Previously she was a correspondent in Silicon Valley and coordinator of the technology pages at NRC. Eva writes and contributes to events as speaker, moderator and chairperson. She has a broad interest, a keen eye and doesn't shy away from complex subjects.`,
     title: `Chair of the Day`,


### PR DESCRIPTION
Per request of one guest I added the ability to show copyright information for speakers' images. **If** the attribute is defined in the `data.js` of `Program` then it will be shown as alt text on the program page and next to the image on the event page. If the attribute is not defined, then the title of the lecture and the guest name is displayed respectively.